### PR TITLE
Set `decoratorsBeforeExport` to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function(options = {}) {
       'flow',
       'doExpressions',
       'objectRestSpread',
-      ['decorators', {decoratorsBeforeExport: false}],
+      ['decorators', {decoratorsBeforeExport: true}],
       'classProperties',
       'exportDefaultFrom',
       'exportNamespaceFrom',


### PR DESCRIPTION
[Madge](https://www.npmjs.com/package/madge) was not reading all of my input files, and after digging into why, it was because this parameter was not set, so babel couldn't parse some of my files. Node source walk will still be able to read all files it could've before, plus ones that use decorator syntax before export with this change.